### PR TITLE
modified shared preamble.

### DIFF
--- a/template.latex/input/shared_preamble.tex
+++ b/template.latex/input/shared_preamble.tex
@@ -44,7 +44,7 @@
 
 
 % floats
-\usepackage[hypcap=false, labelfont=bf]{caption, subcaption}  % caption editing - hypcap warning with hyperref
+\usepackage[hypcap=false, labelfont=bf, format=plain]{caption, subcaption}  % caption editing - hypcap warning with hyperref
 % counter prefixed with section number and therefore reset at each section:
 \counterwithin{figure}{section}
 \counterwithin{table}{section}


### PR DESCRIPTION
format plain allows to use the space beneath the Figure/ Table text in captions for multiline captions.